### PR TITLE
DLL unload crash fix.

### DIFF
--- a/gw2dps/gw2dps.cpp
+++ b/gw2dps/gw2dps.cpp
@@ -93,6 +93,8 @@ uintptr_t stats_shift1 = 0x15c;
 uintptr_t stats_shift2 = 0xa0;
 #endif
 
+DWORD thread_id_hotkey = 0;
+
 // Threads //
 #include "thread.Hotkeys.cpp"
 #include "thread.Dps.cpp"
@@ -1545,6 +1547,9 @@ void GW2LIB::gw2lib_main()
 
 	close_config();
 
+	// make threads clean-up first before interrupting
+	PostThreadMessage(thread_id_hotkey, WM_USER, NULL, NULL);
+
 	// self destruct sequence
 	t1.interrupt(); //t1.join();
 	t2.interrupt(); //t2.join();
@@ -1554,7 +1559,6 @@ void GW2LIB::gw2lib_main()
 	t6.interrupt(); //t6.join();
 	t7.interrupt(); //t7.join();
 
-	unregisterHotkeys();
 	Sleep(1000);
 	return;
 }

--- a/gw2dps/thread.Hotkeys.cpp
+++ b/gw2dps/thread.Hotkeys.cpp
@@ -60,9 +60,12 @@
 
 void registerHotKeyWrapper(int id, string key);
 void registerHotKeyWrapper(int id, string key, bool repeat);
+void unregisterHotkeys();
 
 void threadHotKeys()
-{	
+{
+	thread_id_hotkey = GetCurrentThreadId();
+
 	registerHotKeyWrapper(KILL_APP, read_config_value("Hotkeys.KILL_APP")); // killApp
 
 	registerHotKeyWrapper(HELP, read_config_value("Hotkeys.HELP")); // help
@@ -123,6 +126,8 @@ void threadHotKeys()
 	MSG msg;
 	while (GetMessage(&msg, 0, 0, 0))
 	{
+		if (msg.message == WM_USER) unregisterHotkeys();
+
 		this_thread::interruption_point();
 
 		PeekMessage(&msg, 0, 0, 0, 0x0001);


### PR DESCRIPTION
unregisterHotkeys needed to be called in the same thread as registerHotKey. This should fix dll unloads (F12) and save us developers having to restart the client 1000 times :)